### PR TITLE
Remove remark from sort feature

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -159,12 +159,8 @@ public class Person {
             return occupation.toString();
         case "job title":
             return jobTitle.toString();
-        case "remark":
-            return remark.toString();
         case "status":
             return status.getStatusName().getLabel();
-        case "task": //"should be changed to tasklist but need to check through based on where it is
-            return tasks.toString();
         default:
             throw new IllegalValueException("Attribute does not exists!");
         }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -73,7 +73,6 @@ public class PersonTest {
         assertEquals(person.getOccupation().toString(), person.getAttribute("occupation"));
         assertEquals(person.getJobTitle().toString(), person.getAttribute("job title"));
         assertEquals(person.getAddress().toString(), person.getAttribute("address"));
-        assertEquals(person.getRemark().toString(), person.getAttribute("remark"));
         assertEquals(person.getStatus().getStatusName().getLabel(), person.getAttribute("status"));
     }
 


### PR DESCRIPTION
Removed task and remark from getAttribute method.
Task and remark will be not considered as a lead's attribute which fixes #104 on sorting `remark`.